### PR TITLE
fix(api): clean markdown from gemini json response

### DIFF
--- a/src/services/geminiApi.ts
+++ b/src/services/geminiApi.ts
@@ -137,6 +137,15 @@ export async function getCareerMentorResponse(
   }
 }
 
+function parseJsonFromMarkdown(markdownString: string): any {
+  const jsonRegex = /```json\s*([\s\S]*?)\s*```/;
+  const match = markdownString.match(jsonRegex);
+
+  // If match is found, parse the captured group, otherwise parse the whole string
+  const stringToParse = match ? match[1] : markdownString;
+
+  return JSON.parse(stringToParse.trim());
+}
 // Roadmap Generator API
 export async function generateCareerRoadmap(career: string): Promise<any> {
   const prompt = `Create a detailed career roadmap for "${career}" in India. Return a JSON object with:
@@ -160,7 +169,7 @@ export async function generateCareerRoadmap(career: string): Promise<any> {
 
   try {
     const response = await callGeminiWithRetry(prompt);
-    return JSON.parse(response);
+    return parseJsonFromMarkdown(response);
   } catch (error) {
     console.error("Roadmap API error:", error);
     return getFallbackRoadmap(career);


### PR DESCRIPTION
# fix(api): Clean Markdown from Gemini JSON Response

## Summary
This PR fixes a critical bug where the career roadmap generation would fail due to a `SyntaxError`. The Gemini API occasionally wraps its JSON response in a Markdown code block, which is not valid for `JSON.parse`. This change introduces a robust parsing utility to sanitize the API response before parsing.

## Root Cause
The `generateCareerRoadmap` function in `geminiApi.ts` directly called `JSON.parse()` on the raw string response from the Gemini API. When the response contained Markdown fences (e.g., ` ```json\n{...}\n``` `), it caused a fatal `SyntaxError`.

## Changes
- **`src/services/geminiApi.ts`**:
  - Added a new helper function `parseJsonFromMarkdown` that uses a regular expression to safely extract a JSON string from within a Markdown code block.
  - Updated the `generateCareerRoadmap` function to use this new helper, ensuring the response is clean before parsing.

## Testing
1.  Ran the application locally using `npm run dev`.
2.  Navigated to the Roadmap Generator.
3.  Entered a career and clicked "Generate".
4.  **Verified**: The roadmap was generated successfully without any `SyntaxError` in the browser console.
5.  Passed local checks:
    ```bash
    npm install
    npm run lint
    npm run build
    ```

## Risk & Rollback
- **Risk**: Low. The change is isolated to the response handling logic for a single API call. It correctly handles both raw JSON and Markdown-formatted JSON.
- **Rollback**: This PR can be safely reverted if any issues arise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved errors when generating career roadmaps if responses were wrapped in Markdown code blocks. The app now correctly handles both raw JSON and code-fenced responses, reducing failures and fallbacks.
  - Improved parsing reliability for roadmap results, leading to more consistent outcomes and fewer interruptions for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->